### PR TITLE
Fixing click on icons for safari browser

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -710,6 +710,10 @@ table thead tr th a.desc::after {
   vertical-align: middle;
 }
 
+.table tbody tr td a {
+    display: inline-block;
+}
+
 
 a > svg {
     pointer-events: none;


### PR DESCRIPTION
On Safari we couldn't click on the icons in the list
Adding a display inline-block fix the issue

<img width="1392" alt="Capture d’écran 2020-02-13 à 13 20 35" src="https://user-images.githubusercontent.com/2345926/74434956-beeaa900-4e63-11ea-9aea-4fad48085ce1.png">
