### PR TITLE
Adding a scroll bar to the content

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -523,7 +523,6 @@ body {
 
 
     .content {
-        padding: 10px;
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-auto-rows: 200px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -28,6 +28,12 @@ body {
     font-family: "Source Sans Pro";
 }
 
+.content {
+    display: block;
+    position: relative;
+    padding: 10px;
+}
+
 a,a:visited {
     color: var(--link-color);
     text-decoration: none;
@@ -104,4 +110,19 @@ a:hover {
     color: var(--primary-button-background-color);
     border: 1px solid var(--primary-button-background-color);
     transition: color 0.2s, border 0.2s;
+}
+
+
+@media (min-width: 800px) {
+    body {
+        overflow-y:hidden;
+    }
+
+    .content {
+        display: block;
+        overflow-y: auto;
+        position: relative;
+        height: 100vh;
+        padding: 30px 10px 100px 10px;
+    }
 }


### PR DESCRIPTION
Adding a scrollbar to the content, instead of to the body
- It avoid the scrollbar overlapping the content, starting from Tablet and above
- It also allow to have the statistics always visible in the menu
- fix for #285

![Capture d’écran 2020-03-02 à 15 55 06](https://user-images.githubusercontent.com/2345926/75688315-935b2180-5c9f-11ea-9274-6bfb1bd82e70.png)
