### PR TITLE
Hydrate bool as int

### DIFF
--- a/protected/helpers/ModelHydrator.php
+++ b/protected/helpers/ModelHydrator.php
@@ -103,6 +103,8 @@ class ModelHydrator
             } else {
                 throw new \InvalidArgumentException("Unknown complex type: " . get_class($complex));
             }
+        } elseif (is_bool($complex)) {
+            return $complex ? 1 : 0;
         }
         return $complex;
     }


### PR DESCRIPTION
This change reduces updates where nothing changes.
Normally Yii detects these empty updates and ignores them, but in the case of `tinyint(1)` to `bool` conversion it identifies a change.

This PR instead hydrates booleans into the AR model as `0` or `1`.